### PR TITLE
Adjust formula for amount column

### DIFF
--- a/content/invoice.org
+++ b/content/invoice.org
@@ -18,7 +18,7 @@
 #+TBLNAME: services
 #+BEGIN: clocktable :scope ("timesheet.org") :maxlevel 3
 #+ATTR_LATEX: :align Hlllll
-#+TBLFM: @2$5..@>$5=vsum($2..$4)*$rate;t::@1$5=string("Amount ($)")::@2$6..@>$6=$rate::@1$6=string("Rate ($)")
+#+TBLFM: @2$6..@>$6=vsum($2..$4)*$rate;t::@1$6=string("Amount ($)")::@2$7..@>$7=$rate::@1$7=string("Rate ($)")
 #+END:
 
 #+BEGIN: table
@@ -26,7 +26,7 @@
 | Total Due ($) |
 |---------------|
 | VX.ZY         |
-#+TBLFM: @2$1=remote(services, @2$5)
+#+TBLFM: @2$1=remote(services, @2$6)
 #+END:
 
 * Lisp :noexport:


### PR DESCRIPTION
Prior to this commit, the table formula would overwrite
the second level of a given task's time.  This is due to
the extra column for files added when separating the
timesheet into its own file.

This is resolved by adjusting the table formula by one.