### PR TITLE
Add Elisp function to generate invoice

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,9 +23,9 @@ The file should already contain an example timesheet.
 Then edit ~content/info.org~ to include the correct date, consultant and client info.
 
 Then when it's time to generate the invoice, go into ~content/invoice.org~
-and run ~org-dblock-update~ on the first table to create the /Services Breakdown/
-out of the timesheet info.
+and run ~org-invoice-generate~.
 
-Then go to the next table and run ~org-table-recalculate~ to update the /Balence Due/ field.
+All of the info from the timesheet should be used to
+fill-in the /Services Breakdown/ and /Balance Due/ fields.
 
 Finally, export ~content/invoice.org~ as a LaTex PDF to output the completed invoice.

--- a/content/invoice.org
+++ b/content/invoice.org
@@ -33,13 +33,31 @@
 
 #+NAME: startup
 #+BEGIN_SRC emacs-lisp
-(defadvice org-table-goto-column
+(defun org-invoice-generate ()
+  (interactive)
+
+  ; Activate Org Column Advice
+  (defadvice org-table-goto-column
     (before
      always-make-new-columns
      (n &optional on-delim force)
      activate)
-  "always adds new columns when we move to them"
-  (setq force t))
+    "Always adds new columns for table formulae"
+    (setq force t))
+
+  ; Generate Services Breakdown
+  (beginning-of-buffer)
+  (search-forward "#+TBLNAME: services")
+  (forward-line 1)
+  (org-dblock-update)
+
+  ; Update Balance Due
+  (search-forward "#+BEGIN: table")
+  (forward-line 2)
+  (org-table-recalculate)
+
+  ; Deactivate Org Column Advice
+  (ad-deactivate 'org-table-goto-column))
 #+END_SRC
 
 # Local Variables:


### PR DESCRIPTION
Adds the `org-invoice-generate` method which will automatically generate
the Services Breakdown and Balance Due fields.