### PR TITLE
Allow services breakdown to span more than one page

### DIFF
--- a/content/invoice.org
+++ b/content/invoice.org
@@ -17,7 +17,7 @@
 
 #+TBLNAME: services
 #+BEGIN: clocktable :scope ("timesheet.org") :maxlevel 3
-#+ATTR_LATEX: :align Hllllll
+#+ATTR_LATEX: :align Hllllll :environment longtable
 #+TBLFM: @2$6..@>$6=vsum($2..$5)*$rate;t::@1$6=string("Amount ($)")::@2$7..@>$7=$rate::@1$7=string("Rate ($)")
 #+END:
 


### PR DESCRIPTION
Prior to this commit, if the services breakdown table could
not be fit on one page, it would be included on a separate page
after all other content.

This commit changes this to allow the services breakdown
to remain in the indented location and simply wrap onto the next page.